### PR TITLE
Add a way to convert and finish postcard sightings

### DIFF
--- a/custom_components/birdbuddy/__init__.py
+++ b/custom_components/birdbuddy/__init__.py
@@ -1,19 +1,28 @@
 """The Bird Buddy integration."""
 from __future__ import annotations
 
+from birdbuddy.birds import PostcardSighting
 from birdbuddy.client import BirdBuddy
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, CONF_EMAIL, CONF_PASSWORD
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER, SERVICE_SCHEMA_COLLECT_POSTCARD
 from .coordinator import BirdBuddyDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
 ]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Setup the integration"""
+    # This will register the services even if there's no ConfigEntry yet...
+    setup_services(hass)
+    return True
 
 
 async def async_setup_entry(
@@ -48,3 +57,22 @@ async def async_unload_entry(
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def setup_services(hass: HomeAssistant) -> bool:
+    """Register the BirdBuddy service(s)"""
+
+    async def handle_collect_postcard(service: ServiceCall) -> None:
+        sighting = PostcardSighting(service.data["sighting"])
+        postcard_id = service.data["postcard"]["id"]
+        LOGGER.warning("JHH: service called: %s", service.data)
+        LOGGER.warning("JHH: service: id=%s, sighting=%s", postcard_id, sighting)
+        # Now we can finish the postcard
+
+    LOGGER.info("JHH: registering services")
+    hass.services.async_register(
+        DOMAIN,
+        "collect_postcard",
+        handle_collect_postcard,
+        schema=SERVICE_SCHEMA_COLLECT_POSTCARD,
+    )

--- a/custom_components/birdbuddy/const.py
+++ b/custom_components/birdbuddy/const.py
@@ -1,6 +1,7 @@
 """Constants for the Bird Buddy integration."""
 
 from datetime import timedelta
+from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.helpers import config_validation as cv
 import logging
 import voluptuous as vol
@@ -19,7 +20,7 @@ SERVICE_SCHEMA_COLLECT_POSTCARD = vol.Schema(
     {
         vol.Required("postcard"): cv.has_at_least_one_key("id"),
         vol.Required("sighting"): cv.has_at_least_one_key("sightingReport"),
-        vol.Optional("device_id"): cv.string,  # better?
+        vol.Optional(CONF_DEVICE_ID): cv.string,  # better?
         vol.Optional("strategy"): cv.string,
         # ...?
     }

--- a/custom_components/birdbuddy/const.py
+++ b/custom_components/birdbuddy/const.py
@@ -22,6 +22,7 @@ SERVICE_SCHEMA_COLLECT_POSTCARD = vol.Schema(
         vol.Required("sighting"): cv.has_at_least_one_key("sightingReport"),
         vol.Optional(CONF_DEVICE_ID): cv.string,  # better?
         vol.Optional("strategy"): cv.string,
+        vol.Optional("best_guess_confidence"): vol.Coerce(int),
         # ...?
     }
 )

--- a/custom_components/birdbuddy/const.py
+++ b/custom_components/birdbuddy/const.py
@@ -10,3 +10,5 @@ MANUFACTURER = "Bird Buddy, Inc."
 # Default polling interval.
 # For best performance, this should be less than the access token expiration
 POLLING_INTERVAL = timedelta(minutes=10)
+
+EVENT_NEW_POSTCARD_SIGHTING = f"{DOMAIN}_new_postcard_sighting"

--- a/custom_components/birdbuddy/const.py
+++ b/custom_components/birdbuddy/const.py
@@ -1,7 +1,9 @@
 """Constants for the Bird Buddy integration."""
 
-import logging
 from datetime import timedelta
+from homeassistant.helpers import config_validation as cv
+import logging
+import voluptuous as vol
 
 DOMAIN = "birdbuddy"
 LOGGER = logging.getLogger(__package__)
@@ -12,3 +14,12 @@ MANUFACTURER = "Bird Buddy, Inc."
 POLLING_INTERVAL = timedelta(minutes=10)
 
 EVENT_NEW_POSTCARD_SIGHTING = f"{DOMAIN}_new_postcard_sighting"
+
+SERVICE_SCHEMA_COLLECT_POSTCARD = vol.Schema(
+    {
+        vol.Optional("device_id"): cv.string,  # better?
+        vol.Required("postcard"): cv.has_at_least_one_key("id"),
+        vol.Required("sighting"): cv.has_at_least_one_key("sightingReport"),
+        # ...?
+    }
+)

--- a/custom_components/birdbuddy/const.py
+++ b/custom_components/birdbuddy/const.py
@@ -17,9 +17,10 @@ EVENT_NEW_POSTCARD_SIGHTING = f"{DOMAIN}_new_postcard_sighting"
 
 SERVICE_SCHEMA_COLLECT_POSTCARD = vol.Schema(
     {
-        vol.Optional("device_id"): cv.string,  # better?
         vol.Required("postcard"): cv.has_at_least_one_key("id"),
         vol.Required("sighting"): cv.has_at_least_one_key("sightingReport"),
+        vol.Optional("device_id"): cv.string,  # better?
+        vol.Optional("strategy"): cv.string,
         # ...?
     }
 )

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from birdbuddy.birds import PostcardSighting
+from birdbuddy.birds import PostcardSighting, SightingFinishStrategy
 from birdbuddy.client import BirdBuddy
 from birdbuddy.feed import FeedNode, FeedNodeType
 
@@ -117,13 +117,17 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
         """Handles the `birdbuddy.collect_postcard` service call."""
         sighting = PostcardSighting(data["sighting"])
         postcard_id = data["postcard"]["id"]
+        strategy = SightingFinishStrategy(data.get("strategy", "recognized"))
         LOGGER.debug(
-            "Calling collect_postcard: id=%s, sighting=%s", postcard_id, sighting
+            "Calling collect_postcard: id=%s, sighting=%s, strategy=%s",
+            postcard_id,
+            sighting,
+            strategy,
         )
         success = await self.client.finish_postcard(
             postcard_id,
             sighting,
-            # options: strategy, threshold, etc
+            strategy,
         )
         if success:
             LOGGER.info("Postcard collected to Media")

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -95,7 +95,7 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             await self.client.refresh()
             # refresh_feed() will return only items that are newer than the last seen timestamp
             # if we haven't seen a timestamp, it will return all items.
-            feed = await self.client.refresh_feed(since="2022-12-06T00:00:00.000Z")
+            feed = await self.client.refresh_feed()
             # Check for any new postcards that we can handle, and handle them:
             await self._process_feed(feed)
         except Exception as exc:

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -1,15 +1,21 @@
 """Data Update coordinator for ZAMG weather data."""
 from __future__ import annotations
+from datetime import datetime
 
 from birdbuddy.client import BirdBuddy
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, EventOrigin
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from .const import DOMAIN, LOGGER, POLLING_INTERVAL
+from .const import (
+    DOMAIN,
+    EVENT_NEW_POSTCARD_SIGHTING,
+    LOGGER,
+    POLLING_INTERVAL,
+)
 
 from .device import BirdBuddyDevice
 
@@ -20,6 +26,8 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
     config_entry: ConfigEntry
     client: BirdBuddy
     feeders: dict[str, BirdBuddyDevice]
+
+    _last_feed_item: datetime | None
 
     def __init__(
         self,
@@ -36,9 +44,55 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             update_interval=POLLING_INTERVAL,
         )
 
+    async def _process_feed(self, feed: dict) -> bool:
+        """Attempt to process new feed items.
+
+        There are some options for how we can process these:
+        - If the sighting contains a recognized bird, we can finish it automatically
+          using :func:`BirdBuddy.finish_postcard`.
+        - For all new postcards, we can simply emit a HA event, and leave it up to
+          the user's automations to finish them, however (and if) the user wants.
+        """
+        postcards = [
+            edge["node"]
+            for edge in feed["edges"]
+            if edge["node"]["__typename"] == "FeedItemNewPostcard"
+        ]
+        for postcard in postcards:
+            LOGGER.debug("A new postcard is ready to process: %s", postcard)
+            if not self.hass.bus.listeners.get(EVENT_NEW_POSTCARD_SIGHTING):
+                # if no one is listening, no sense in getting sighting data
+                continue
+
+            # emit a new event with sighting data and postcard data
+            # expose services that can:
+            # 1. auto-collect a recognized bird
+            # 2. manually assign a species
+            # 3. auto-collect a best-guess species, using sightingReport confidence
+            # 4. assign the sighting as "mystery visitor"
+            # 5. all-in-one service that can choose the best option of 1, 3, or 4
+            # Automations could use the sighting media URLs to do additional AI processing,
+            # such as with Merlin or other AI classifiers, and then do #2 with the results.
+            # If this is a viable option, we can supply a Recipe in docs to show how this could
+            # be done. Similarly, we can supply some default blueprints to handle this with
+            # user input.
+            sighting = self.client.sighting_from_postcard(postcard_id=postcard["id"])
+            data = {
+                "postcard": postcard,
+                "sighting": sighting,
+            }
+            self.hass.bus.fire(
+                event_type=EVENT_NEW_POSTCARD_SIGHTING,
+                event_data=data,
+                origin=EventOrigin.remote,
+            )
+
     async def _async_update_data(self) -> BirdBuddy:
         try:
             await self.client.refresh()
+            feed = await self.client.refresh_feed()
+            # Check for any new postcards that we can handle, and handle them:
+            await self._process_feed(feed)
         except Exception as exc:
             raise UpdateFailed(exc) from exc
 

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -80,6 +80,7 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             # user input.
             sighting = await self.client.sighting_from_postcard(postcard=postcard)
             data = {
+                # "device_id": or some way to identify which account to use
                 "postcard": postcard.data,
                 "sighting": sighting.data,
             }

--- a/custom_components/birdbuddy/device_trigger.todo
+++ b/custom_components/birdbuddy/device_trigger.todo
@@ -1,0 +1,89 @@
+"""Provides device triggers for Bird Buddy."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN, LOGGER
+from .util import _find_coordinator_by_device
+
+TRIGGER_TYPES = {"new_postcard"}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    config = TRIGGER_SCHEMA(config)
+    coordinator = _find_coordinator_by_device(hass, config[CONF_DEVICE_ID])
+    if not coordinator:
+        raise InvalidDeviceAutomationConfig()
+    return config
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, Any]]:
+    """List device triggers for Bird Buddy devices."""
+    triggers = []
+
+    # TODO: get entities, like BirdBuddyStateEntity to attach node state triggers
+
+    base_trigger = {
+        CONF_PLATFORM: "device",
+        CONF_DEVICE_ID: device_id,
+        CONF_DOMAIN: DOMAIN,
+    }
+
+    # new postcard trigger
+    triggers.append({**base_trigger, CONF_TYPE: "new_postcard"})
+    LOGGER.warning("JHH: returning triggers: %s", triggers)
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    LOGGER.warning("JHH Attaching trigger: %s, %s, %s", config, action, trigger_info)
+    event_data = {
+        CONF_DEVICE_ID: config[CONF_DEVICE_ID],
+        CONF_TYPE: config[CONF_TYPE],
+    }
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: config[CONF_TYPE],
+            event_trigger.CONF_EVENT_DATA: event_data,
+        }
+    )
+    LOGGER.warning("JHH transformed event config: %s", event_config)
+    return await event_trigger.async_attach_trigger(
+        hass, event_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/birdbuddy/services.yaml
+++ b/custom_components/birdbuddy/services.yaml
@@ -4,8 +4,37 @@ collect_postcard:
   # target:
   #   device:
   #     # Technically we don't care about Feeder, just account...
+  #     # But associating a device lets us look up the coordinator and client
   #     integration: birdbuddy
   fields:
+    strategy:
+      name: Strategy for collecting the postcard
+      description: "Strategy can be one of
+        * `recognized` - Collect the postcard only if it was a recognized bird. Unrecognized birds will
+          be ignored.
+        * `best_guess` - Collect `recognized` birds, as well as choosing the highest-confidence species
+          that Bird Buddy suggested. Optionally set the confidence threshold (defaults to 10).
+        * `mystery` - Collect as `best_guess`, and anything remaining will be finished as a \"Mystery
+          Visitor\".
+        "
+      required: false
+      default: "recognized"
+      selector:
+        select:
+          options:
+            - "recognized"
+            - "best_guess"
+            - "mystery"
+    best_guess_confidence:
+      name: Best-guess confidence threshold
+      description: Confidence threshold for auto-accepting Bird Buddy's recommendations.
+      default: 10
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
     postcard:
       name: Postcard data
       description: Data from the FeedNode representing the postcard.
@@ -18,10 +47,12 @@ collect_postcard:
     sighting:
       name: Sighting data
       description: Data from the PostcardSighting object after converting the postcard to a sighting.
-        This corresponds to the `.sighting` data received in the Event.
+        This corresponds to the `.sighting` data received in the Event. This should generally just be
+        passed through from an automation.
       required: true
       fields:
         feeder:
+          # TODO: not really required, but it is used in the string representation of the Sighting object.
           required: true
         sightingReport:
           name: SightingReport data
@@ -32,5 +63,5 @@ collect_postcard:
               required: true
               fields:
                 species:
-                  required: true
+                  required: false
 

--- a/custom_components/birdbuddy/services.yaml
+++ b/custom_components/birdbuddy/services.yaml
@@ -1,0 +1,36 @@
+collect_postcard:
+  name: Collect a Postcard
+  description: Finish a Postcard by adding it to your Bird Buddy Collections.
+  # target:
+  #   device:
+  #     # Technically we don't care about Feeder, just account...
+  #     integration: birdbuddy
+  fields:
+    postcard:
+      name: Postcard data
+      description: Data from the FeedNode representing the postcard.
+        This corresponds to the `.postcard` data received in the Event.
+      required: true
+      fields:
+        id:
+          name: The postcard (feed item) id
+          required: true
+    sighting:
+      name: Sighting data
+      description: Data from the PostcardSighting object after converting the postcard to a sighting.
+        This corresponds to the `.sighting` data received in the Event.
+      required: true
+      fields:
+        feeder:
+          required: true
+        sightingReport:
+          name: SightingReport data
+          required: true
+          fields:
+            sightings:
+              name: List of sightings in this report
+              required: true
+              fields:
+                species:
+                  required: true
+

--- a/custom_components/birdbuddy/strings.json
+++ b/custom_components/birdbuddy/strings.json
@@ -35,5 +35,10 @@
         }
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "new_postcard": "A new postcard is ready"
+    }
   }
 }

--- a/custom_components/birdbuddy/strings.json
+++ b/custom_components/birdbuddy/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "title": "Bird Buddy",
     "step": {
       "user": {
         "title": "Fill in your Bird Buddy login credentials",
@@ -22,6 +23,8 @@
     "sensor": {
       "feeder_state": {
         "state": {
+          "DEEP_SLEEP": "Sleeping",
+          "FIRMWARE_UPDATE": "Updating firmware",
           "OFFLINE": "Offline",
           "OFF_GRID": "Off-grid",
           "ONLINE": "Online",

--- a/custom_components/birdbuddy/translations/en.json
+++ b/custom_components/birdbuddy/translations/en.json
@@ -19,6 +19,11 @@
         },
         "title": "Bird Buddy"
     },
+    "device_automation": {
+        "trigger_type": {
+            "new_postcard": "A new postcard is ready"
+        }
+    },
     "entity": {
         "sensor": {
             "feeder_state": {

--- a/custom_components/birdbuddy/translations/en.json
+++ b/custom_components/birdbuddy/translations/en.json
@@ -1,0 +1,39 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "email": "Email",
+                    "password": "Password"
+                },
+                "title": "Fill in your Bird Buddy login credentials"
+            }
+        },
+        "title": "Bird Buddy"
+    },
+    "entity": {
+        "sensor": {
+            "feeder_state": {
+                "state": {
+                    "DEEP_SLEEP": "Sleeping",
+                    "FIRMWARE_UPDATE": "Updating firmware",
+                    "OFFLINE": "Offline",
+                    "OFF_GRID": "Off-grid",
+                    "ONLINE": "Online",
+                    "OUT_OF_FEEDER": "Out of feeder",
+                    "READY_TO_STREAM": "Ready",
+                    "STREAMING": "Streaming",
+                    "TAKING_POSTCARDS": "Taking postcards"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/birdbuddy/util.py
+++ b/custom_components/birdbuddy/util.py
@@ -1,0 +1,17 @@
+"""Bird Buddy utilities"""
+
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import BirdBuddyDataUpdateCoordinator
+
+
+def _find_coordinator_by_feeder(
+    hass: HomeAssistant,
+    feeder_id: str,
+) -> BirdBuddyDataUpdateCoordinator:
+    """Find the first matching coordinator containing this `feeder_id`."""
+    coordinators: list[BirdBuddyDataUpdateCoordinator] = list(
+        hass.data[DOMAIN].values()
+    )
+    return next((c for c in coordinators if feeder_id in c.feeders), None)


### PR DESCRIPTION
* New event: `birdbuddy_new_postcard_sighting`
* New service: `birdbuddy.collect_postcard`

A new automation can be created with the event as a trigger, calling the service by passing through the event trigger data. Example automation YAML:
```yaml
alias: Collect Bird Buddy Sightings
description: ""
trigger:
  - platform: event
    event_type: birdbuddy_new_postcard_sighting
action:
  - service: birdbuddy.collect_postcard
    data_template:
      strategy: best_guess
      postcard: "{{ trigger.event.data.postcard }}"
      sighting: "{{ trigger.event.data.sighting }}"
mode: single
```
Other options for `data_template.strategy` include `recognized` (only collect the postcard if Bird Buddy recognized the species) and `mystery` (not yet implemented, but will collect all unknown birds as mystery visitors). With the `best_guess` strategy, any "cannot decide" postcard species will try to use the highest-confidence species match, as long as the confidence is above 10% for now. Just be warned that the highest-confidence species is often incorrect and would require manual correction in many cases.

Once "Mystery Visitor" is implemented, that might be the better choice (strategy=mystery, best_guess_confidence=80; or some other sufficiently high confidence score). That way we would only select the highest confidence match if it's at least 80% (not sure what value makes sense yet, because I don't know at what confidence level BB considers it to be "Recognized")