### PR TITLE
Update collections on unlocking species

### DIFF
--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from birdbuddy.birds import PostcardSighting, SightingFinishStrategy
 from birdbuddy.client import BirdBuddy
 from birdbuddy.feed import FeedNode, FeedNodeType
+from birdbuddy.media import Collection
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, EventOrigin
@@ -58,6 +59,13 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
         postcards = [
             node for node in feed if node.node_type == FeedNodeType.NewPostcard
         ]
+
+        for node in feed:
+            if node.node_type == FeedNodeType.SpeciesUnlocked and (
+                c := Collection(node.get("collection"))
+            ):
+                LOGGER.info("Recently unlocked species: %s", c.bird_name)
+                self.client.collections.setdefault(c.collection_id, c)
 
         LOGGER.debug("Found postcards %s", postcards)
         for postcard in postcards:

--- a/custom_components/birdbuddy/media_source.py
+++ b/custom_components/birdbuddy/media_source.py
@@ -111,7 +111,10 @@ class BirdBuddyMediaSource(MediaSource):
                 device = self._get_device_or_raise(device_id)
 
             if config and device and collection_id:
-                if len(coordinator.client.collections) == 0:
+                if (
+                    not coordinator.client.collections
+                    or collection_id not in coordinator.client.collections
+                ):
                     # FIXME: cache it at all?
                     await coordinator.client.refresh_collections()
                 collection = coordinator.client.collections[collection_id]
@@ -123,7 +126,7 @@ class BirdBuddyMediaSource(MediaSource):
                 # Feeder selected: show collections on that feeder
                 # TODO: is this right? Are collections feeder based or login based?
                 # TODO: pass refresh_collections() to build
-                if len(coordinator.client.collections) == 0:
+                if not coordinator.client.collections:
                     # FIXME: better way to refresh?
                     await coordinator.client.refresh_collections()
                 # for a feeder/device, now look up the collections (one per bird?)


### PR DESCRIPTION
When processing the feed, if we get a new UnlockedSpecies item, patch the collections with the new species collection info.

Fixes #15