### PR TITLE
Add share-media option when collecting postcards

### DIFF
--- a/custom_components/birdbuddy/const.py
+++ b/custom_components/birdbuddy/const.py
@@ -22,9 +22,9 @@ SERVICE_SCHEMA_COLLECT_POSTCARD = vol.Schema(
     {
         vol.Required("postcard"): cv.has_at_least_one_key("id"),
         vol.Required("sighting"): cv.has_at_least_one_key("sightingReport"),
-        vol.Optional(CONF_DEVICE_ID): cv.string,  # better?
+        vol.Optional(CONF_DEVICE_ID): cv.string,
         vol.Optional("strategy"): cv.string,
         vol.Optional("best_guess_confidence"): vol.Coerce(int),
-        # ...?
+        vol.Optional("share_media"): vol.Coerce(bool),
     }
 )

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -132,6 +132,9 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
         sighting = PostcardSighting(data["sighting"])
         postcard_id = data["postcard"]["id"]
         strategy = SightingFinishStrategy(data.get("strategy", "recognized"))
+        confidence = data.get("best_guess_confidence", None)
+        share_media = data.get("share_media", False)
+
         LOGGER.debug(
             "Calling collect_postcard: id=%s, sighting=%s, strategy=%s",
             postcard_id,
@@ -142,6 +145,8 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             postcard_id,
             sighting,
             strategy,
+            confidence_threshold=confidence,
+            share_media=share_media,
         )
         if success:
             LOGGER.info("Postcard collected to Media")

--- a/custom_components/birdbuddy/services.yaml
+++ b/custom_components/birdbuddy/services.yaml
@@ -19,6 +19,7 @@ collect_postcard:
         "
       required: false
       default: "recognized"
+      example: "recognized"
       selector:
         select:
           options:
@@ -29,18 +30,31 @@ collect_postcard:
       name: Best-guess confidence threshold
       description: Confidence threshold for auto-accepting Bird Buddy's recommendations.
       default: 10
+      example: 10
       selector:
         number:
           min: 0
           max: 100
           step: 1
           unit_of_measurement: "%"
+    share_media:
+      name: Share postcard media
+      description: Whether each media image should be shared with the community.
+      default: false
+      example: false
+      selector:
+        boolean:
     postcard:
       name: Postcard data
       description: Data from the FeedNode representing the postcard.
         This corresponds to the `.postcard` data received in the Event.
         The only field that matters is `.id`
       required: true
+      example:
+        - '{"id": "$postcardFeedItemId"}'
+        - "{{ trigger.event.data.postcard }}"
+      selector:
+        object:
       # TODO: support nested fields
       # fields:
       #   id:
@@ -52,6 +66,11 @@ collect_postcard:
         This corresponds to the `.sighting` data received in the Event. This should generally just be
         passed through from an automation.
       required: true
+      example:
+        - '{"feeder":{"id":"$feederId"}, "sightingReport":{"sightings":[]}}'
+        - "{{ trigger.event.data.sighting }}"
+      selector:
+        object:
       # TODO: support nested fields
       # fields:
       #   feeder:


### PR DESCRIPTION
This allows the service call to indicate whether you want the collected postcard's media to be shared with the community automatically.

Defaults to false, so requires explicit opt-in by passing
`share_media: True` in the service call to `birdbuddy.collect_postcard`