### PR TITLE
Fixes for firmware updates

### DIFF
--- a/custom_components/birdbuddy/update.py
+++ b/custom_components/birdbuddy/update.py
@@ -89,7 +89,10 @@ class BirdBuddyUpdate(BirdBuddyMixin, UpdateEntity):
             return False
         if self.__update_state.progress is None:
             return False
-        return self.__update_state.progress
+        if self.__update_state.progress == 0:
+            # Return True to show an indeterminate progress indicator
+            return True
+        return int(self.__update_state.progress)
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any


### PR DESCRIPTION
Bird Buddy update status might take some time to get started, and during that time, the progress indicator would remain at 0. However, HA treats 0 as nothing is happening. Once the progress changes to 1 or greater, then it will show the installation progress. Instead of 0, if we return `True`, then HA will show an indeterminate progress indicator to at least show that something is happening. Then once it becomes 1% or greater, the UI will update with real progress.

This also catches any remote errors during the firmware process, in order to show a more friendly error message.