### PR TITLE
Improve recent visitors

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from birdbuddy.birds import PostcardSighting, SightingFinishStrategy
 from birdbuddy.client import BirdBuddy
 from birdbuddy.feed import FeedNode, FeedNodeType
 from birdbuddy.media import Collection
+from birdbuddy.sightings import PostcardSighting, SightingFinishStrategy
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, EventOrigin
@@ -119,7 +119,7 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
 
         feeders = {id: BirdBuddyDevice(f) for (id, f) in self.client.feeders.items()}
         # pylint: disable=invalid-name
-        for (i, f) in feeders.items():
+        for i, f in feeders.items():
             if i in self.feeders:
                 self.feeders[i].update(f)
             else:

--- a/custom_components/birdbuddy/sensor.py
+++ b/custom_components/birdbuddy/sensor.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from birdbuddy.birds import PostcardSighting
 from birdbuddy.feed import FeedNodeType
 from birdbuddy.media import Collection, Media, is_media_expired
+from birdbuddy.sightings import PostcardSighting
 
 from homeassistant.components.sensor import (
     RestoreSensor,

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,10 +6,10 @@ python-graphql-client==0.4.3
 
 # for tests
 codecov==2.1.12
-coverage==7.0.0
-pytest==7.2.0
+coverage==7.0.5
+pytest==7.2.1
 pytest-cov==3.0.0
 pytest-aiohttp==1.0.4
 pytest-asyncio==0.20.2
-pytest-homeassistant-custom-component==0.12.46
+pytest-homeassistant-custom-component==0.12.55
 

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -72,9 +72,17 @@ async def test_get_triggers(
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_fires_on_postcard_event(hass, calls):
+async def test_fires_on_postcard_event(
+    hass, device_reg: device_registry.DeviceRegistry, calls
+):
     """Test new-postcard event firing triggers the device."""
-    assert await setup_automation(hass, "deviceid", "feeder1", "new_postcard")
+    config_entry = MockConfigEntry(domain="birdbuddy", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "feeder1")},
+    )
+    assert await setup_automation(hass, device_entry.id, "feeder1", "new_postcard")
 
     message = {"sighting": {"feeder": {"id": "feeder1"}}, "postcard": {}}
     hass.bus.async_fire(EVENT_NEW_POSTCARD_SIGHTING, message)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,7 @@
 """Test the Bird Buddy config flow."""
 from unittest.mock import ANY, patch
 
-from birdbuddy.birds import SightingFinishStrategy
+from birdbuddy.sightings import SightingFinishStrategy
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.setup import async_setup_component
 import pytest


### PR DESCRIPTION
As discussed in the [community thread](https://community.home-assistant.io/t/custom-component-bird-buddy-smart-bird-feeder/497464/100?u=madcoder), we should be able to improve the "recent visitor" entity to work more like the "best guess" postcard collection strategy. If the species is not recognized, it will report the highest-confidence suggestion instead.