### PR TITLE
Delete orphaned devices

### DIFF
--- a/custom_components/birdbuddy/__init__.py
+++ b/custom_components/birdbuddy/__init__.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
             entry,
             title=client.user.name,
             options={},
-            unique_id=entry[CONF_EMAIL],
+            unique_id=entry.data[CONF_EMAIL],
         )
 
     await hass.config_entries.async_forward_entry_setups(

--- a/custom_components/birdbuddy/device_trigger.py
+++ b/custom_components/birdbuddy/device_trigger.py
@@ -47,9 +47,11 @@ async def async_validate_trigger_config(
 ) -> ConfigType:
     """Validate config."""
     config = TRIGGER_SCHEMA(config)
-    coordinator = _find_coordinator_by_device(hass, config[CONF_DEVICE_ID])
-    if not coordinator:
-        raise InvalidDeviceAutomationConfig()
+    try:
+        coordinator = _find_coordinator_by_device(hass, config[CONF_DEVICE_ID])
+        assert coordinator
+    except Exception as exc:
+        raise InvalidDeviceAutomationConfig() from exc
     return config
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Test component setup."""
 from unittest.mock import patch, PropertyMock
+from birdbuddy.user import BirdBuddyUser
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -34,7 +35,11 @@ async def test_setup_entry(hass: HomeAssistant):
     ), patch(
         "birdbuddy.client.BirdBuddy.feeders",
         new_callable=PropertyMock,
-        return_value={"feeder1": {"id": "feeder1", "name": "Test Feeder"}}
+        return_value={"feeder1": {"id": "feeder1", "name": "Test Feeder"}},
+    ), patch(
+        "birdbuddy.client.BirdBuddy.user",
+        new_callable=PropertyMock,
+        return_value=BirdBuddyUser({"name": "Test Account"}),
     ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 


### PR DESCRIPTION
This looks for any BB devices in the registry, that do not have a matching entry in the account's feeders list, and removes those.

If there were any automations with a device trigger for that device, the Automations integration will fails to validate the device trigger, and automatically disable that automation. If this happens you will see an error in the logs. You can then delete the automation manually, or update the device trigger to a new device id and reenable it.