### PR TITLE
Add support for remote translations

### DIFF
--- a/custom_components/birdbuddy/__init__.py
+++ b/custom_components/birdbuddy/__init__.py
@@ -41,6 +41,7 @@ async def async_setup_entry(
     """Set up Bird Buddy from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     client = BirdBuddy(entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD])
+    client.language_code = hass.config.language
     coordinator = BirdBuddyDataUpdateCoordinator(hass, client, entry)
 
     hass.data[DOMAIN][entry.entry_id] = coordinator


### PR DESCRIPTION
pybirdbuddy v0.0.14 adds support for setting the remote language code, which will result in translated bird names, among other strings.

We use the local `hass.config.language` to set the preferred language code during integration setup, so if the language is modified, the change won't take effect until the next time that the integration is reloaded.

Closes jhansche/pybirdbuddy#14