### PR TITLE
Recent visitor image entity

### DIFF
--- a/custom_components/birdbuddy/__init__.py
+++ b/custom_components/birdbuddy/__init__.py
@@ -1,4 +1,5 @@
 """The Bird Buddy integration."""
+
 from __future__ import annotations
 
 from birdbuddy.client import BirdBuddy
@@ -21,6 +22,7 @@ from .util import _find_coordinator_by_feeder
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.IMAGE,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/custom_components/birdbuddy/__init__.py
+++ b/custom_components/birdbuddy/__init__.py
@@ -18,7 +18,7 @@ from .const import (
     SERVICE_SCHEMA_COLLECT_POSTCARD,
 )
 from .coordinator import BirdBuddyDataUpdateCoordinator
-from .util import _find_coordinator_by_feeder
+from .hass_util import _find_coordinator_by_feeder
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,

--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -1,28 +1,21 @@
 """Data Update coordinator for Bird Buddy."""
 
 from __future__ import annotations
-from collections.abc import Callable
 
 from birdbuddy.client import BirdBuddy
 from birdbuddy.feed import FeedNode, FeedNodeType
 from birdbuddy.feeder import Feeder
-from birdbuddy.media import Collection, Media
+from birdbuddy.media import Collection
 from birdbuddy.sightings import PostcardSighting, SightingFinishStrategy
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, EventOrigin
+from homeassistant.core import EventOrigin, HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     CALLBACK_TYPE,
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from .const import (
-    DOMAIN,
-    EVENT_NEW_POSTCARD_SIGHTING,
-    LOGGER,
-    POLLING_INTERVAL,
-)
 
+from .const import DOMAIN, EVENT_NEW_POSTCARD_SIGHTING, LOGGER, POLLING_INTERVAL
 from .device import BirdBuddyDevice
 from .visitors import RecentVisitors, VisitorCallback
 
@@ -41,6 +34,7 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
         client: BirdBuddy,
         entry: ConfigEntry,
     ) -> None:
+        """Initialize the BirdBuddy data coordinator."""
         self.client = client
         self.feeders = {}
         self.visitors = {}
@@ -142,11 +136,11 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
         return self.client
 
     async def handle_collect_postcard(self, data: dict[str, any]) -> bool:
-        """Handles the `birdbuddy.collect_postcard` service call."""
+        """Handle the `birdbuddy.collect_postcard` service call."""
         sighting = PostcardSighting(data["sighting"])
         postcard_id = data["postcard"]["id"]
         strategy = SightingFinishStrategy(data.get("strategy", "recognized"))
-        confidence = data.get("best_guess_confidence", None)
+        confidence = data.get("best_guess_confidence")
         share_media = data.get("share_media", False)
 
         LOGGER.debug(

--- a/custom_components/birdbuddy/device_trigger.py
+++ b/custom_components/birdbuddy/device_trigger.py
@@ -1,4 +1,5 @@
 """Provides device triggers for Bird Buddy."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -27,7 +28,7 @@ from .const import (
     EVENT_NEW_POSTCARD_SIGHTING,
     TRIGGER_TYPE_POSTCARD,
 )
-from .util import (
+from .hass_util import (
     _find_coordinator_by_device,
     _feeder_id_for_device,
 )

--- a/custom_components/birdbuddy/hass_util.py
+++ b/custom_components/birdbuddy/hass_util.py
@@ -1,0 +1,54 @@
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .const import DOMAIN
+from .coordinator import BirdBuddyDataUpdateCoordinator
+
+
+def _feeder_id_for_device(
+    hass: HomeAssistant,
+    device_id: str,
+) -> str:
+    """Return the Bird Buddy Feeder ID for this `device_id`."""
+    dev_reg = dr.async_get(hass)
+    if not (device_entry := dev_reg.async_get(device_id)):
+        raise ValueError(f"Device ID {device_id} not found")
+    return next(id for (d, id) in device_entry.identifiers if d == DOMAIN)
+
+
+def _find_coordinator_by_feeder(
+    hass: HomeAssistant,
+    feeder_id: str,
+) -> BirdBuddyDataUpdateCoordinator:
+    """Find the first matching coordinator containing this `feeder_id`."""
+    coordinators: list[BirdBuddyDataUpdateCoordinator] = list(
+        hass.data[DOMAIN].values()
+    )
+    return next((c for c in coordinators if feeder_id in c.feeders), None)
+
+
+def _find_coordinator_by_device(
+    hass: HomeAssistant,
+    device_id: str,
+) -> BirdBuddyDataUpdateCoordinator:
+    """Find the first coordinator for this `device_id`."""
+    dev_reg = dr.async_get(hass)
+    if not (device_entry := dev_reg.async_get(device_id)):
+        raise ValueError(f"Device ID {device_id} not found")
+
+    config_entry_ids = device_entry.config_entries
+    entry = next(
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.entry_id in config_entry_ids
+    )
+
+    if entry and entry.state != ConfigEntryState.LOADED:
+        raise ValueError(f"Device {device_id} config entry is not loaded")
+    if entry is None or entry.entry_id not in hass.data[DOMAIN]:
+        raise ValueError(
+            f"Device {device_id} is not from an existing birdbuddy config entry"
+        )
+    coordinator: BirdBuddyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    return coordinator

--- a/custom_components/birdbuddy/image.py
+++ b/custom_components/birdbuddy/image.py
@@ -1,0 +1,123 @@
+"""The Bird Buddy image entity."""
+
+from birdbuddy.feed import FeedNodeType
+from birdbuddy.media import Media, is_media_expired
+from birdbuddy.sightings import PostcardSighting
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, EVENT_NEW_POSTCARD_SIGHTING
+from .coordinator import BirdBuddyDataUpdateCoordinator
+from .device import BirdBuddyDevice
+from .entity import BirdBuddyMixin
+from .util import _find_media_with_species
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+    coordinator: BirdBuddyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    feeders = coordinator.feeders.values()
+    async_add_entities(
+        BirdBuddyRecentVisitorImageEntity(hass, f, coordinator) for f in feeders
+    )
+
+
+class BirdBuddyRecentVisitorImageEntity(BirdBuddyMixin, ImageEntity):
+    """The latest visitor image entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Recent Visitor Image"
+
+    _latest_media: Media | None = None
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        feeder: BirdBuddyDevice,
+        coordinator: BirdBuddyDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the entity."""
+        ImageEntity.__init__(self, hass)
+        BirdBuddyMixin.__init__(self, feeder, coordinator)
+        self._latest_media = None
+        self._attr_unique_id = f"{self.feeder.id}-recent-image"
+
+    def image(self) -> bytes | None:
+        """Return the image bytes."""
+        # See async_image()
+        return None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        @callback
+        def filter_my_postcards(event: Event) -> bool:
+            # FIXME: This signature changed in 2024.4
+            data = event if callable(getattr(event, "get", None)) else event.data
+            return self.feeder.id == (
+                data.get("sighting", {}).get("feeder", {}).get("id")
+            )
+
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                EVENT_NEW_POSTCARD_SIGHTING,
+                self._on_new_postcard,
+                event_filter=filter_my_postcards,
+            )
+        )
+
+        await self._update_latest_visitor()
+
+    async def _on_new_postcard(self, event: Event | None = None) -> None:
+        """ """
+        postcard = PostcardSighting(event.data["sighting"])
+
+        assert postcard.report.sightings
+        assert postcard.medias
+
+        # media has created_at
+        # but sightings[] does not.
+        media = next(iter(postcard.medias), None)
+        self._update_url(media)
+
+    async def _update_latest_visitor(self) -> None:
+        feed = await self.coordinator.client.feed()
+
+        items = feed.filter(
+            of_type=[
+                FeedNodeType.SpeciesSighting,
+                FeedNodeType.SpeciesUnlocked,
+                FeedNodeType.NewPostcard,
+                FeedNodeType.CollectedPostcard,
+            ],
+        )
+
+        my_items = _find_media_with_species(self.feeder.id, items)
+
+        if latest := max(my_items, default=None, key=lambda x: x.created_at):
+            self._latest_media = Media(latest["media"])
+            self._update_url(self._latest_media)
+            self.async_write_ha_state()
+
+    def _update_url(self, media: Media) -> None:
+        if (
+            media
+            and (url := media.content_url or media.thumbnail_url)
+            and (created_at := media.created_at)
+            and not is_media_expired(url)
+        ):
+            self._attr_image_url = url
+            self._attr_image_last_updated = created_at
+            self._attr_entity_picture = url
+        elif is_media_expired(self._attr_image_url):
+            # Clear it
+            self._attr_image_url = None
+            self._attr_image_last_updated = None
+            self._attr_entity_picture = None

--- a/custom_components/birdbuddy/image.py
+++ b/custom_components/birdbuddy/image.py
@@ -80,6 +80,7 @@ class BirdBuddyRecentVisitorImageEntity(BirdBuddyMixin, ImageEntity):
             self._attr_image_url = url
             self._attr_image_last_updated = created_at
             self._attr_entity_picture = url
+            self._cached_image = None
         elif (url := self.image_url) and url is not UNDEFINED and is_media_expired(url):
             # Clear it
             self._attr_image_url = None

--- a/custom_components/birdbuddy/image.py
+++ b/custom_components/birdbuddy/image.py
@@ -1,19 +1,16 @@
 """The Bird Buddy image entity."""
 
-from birdbuddy.feed import FeedNodeType
 from birdbuddy.media import Media, is_media_expired
-from birdbuddy.sightings import PostcardSighting
-
-from homeassistant.components.image import ImageEntity
+from homeassistant.components.image import UNDEFINED, ImageEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, EVENT_NEW_POSTCARD_SIGHTING
+from .const import DOMAIN, LOGGER
 from .coordinator import BirdBuddyDataUpdateCoordinator
 from .device import BirdBuddyDevice
 from .entity import BirdBuddyMixin
-from .util import _find_media_with_species
+from .visitors import RecentVisitors
 
 
 async def async_setup_entry(
@@ -56,55 +53,17 @@ class BirdBuddyRecentVisitorImageEntity(BirdBuddyMixin, ImageEntity):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-
-        @callback
-        def filter_my_postcards(event: Event) -> bool:
-            # FIXME: This signature changed in 2024.4
-            data = event if callable(getattr(event, "get", None)) else event.data
-            return self.feeder.id == (
-                data.get("sighting", {}).get("feeder", {}).get("id")
-            )
-
         self.async_on_remove(
-            self.hass.bus.async_listen(
-                EVENT_NEW_POSTCARD_SIGHTING,
-                self._on_new_postcard,
-                event_filter=filter_my_postcards,
+            self.coordinator.add_visitor_listener(
+                self.feeder,
+                self._on_recent_visitor,
             )
         )
 
-        await self._update_latest_visitor()
-
-    async def _on_new_postcard(self, event: Event | None = None) -> None:
-        """ """
-        postcard = PostcardSighting(event.data["sighting"])
-
-        assert postcard.report.sightings
-        assert postcard.medias
-
-        # media has created_at
-        # but sightings[] does not.
-        media = next(iter(postcard.medias), None)
-        self._update_url(media)
-
-    async def _update_latest_visitor(self) -> None:
-        feed = await self.coordinator.client.feed()
-
-        items = feed.filter(
-            of_type=[
-                FeedNodeType.SpeciesSighting,
-                FeedNodeType.SpeciesUnlocked,
-                FeedNodeType.NewPostcard,
-                FeedNodeType.CollectedPostcard,
-            ],
-        )
-
-        my_items = _find_media_with_species(self.feeder.id, items)
-
-        if latest := max(my_items, default=None, key=lambda x: x.created_at):
-            self._latest_media = Media(latest["media"])
-            self._update_url(self._latest_media)
-            self.async_write_ha_state()
+    @callback
+    def _on_recent_visitor(self, visitors: RecentVisitors) -> None:
+        self._update_url(visitors.latest_media)
+        self.async_write_ha_state()
 
     def _update_url(self, media: Media) -> None:
         if (
@@ -113,10 +72,15 @@ class BirdBuddyRecentVisitorImageEntity(BirdBuddyMixin, ImageEntity):
             and (created_at := media.created_at)
             and not is_media_expired(url)
         ):
+            LOGGER.debug(
+                "Updating latest image for %s: %s",
+                self.feeder.name,
+                url,
+            )
             self._attr_image_url = url
             self._attr_image_last_updated = created_at
             self._attr_entity_picture = url
-        elif is_media_expired(self._attr_image_url):
+        elif (url := self.image_url) and url is not UNDEFINED and is_media_expired(url):
             # Clear it
             self._attr_image_url = None
             self._attr_image_last_updated = None

--- a/custom_components/birdbuddy/util.py
+++ b/custom_components/birdbuddy/util.py
@@ -2,65 +2,6 @@
 
 from birdbuddy.feed import FeedNode
 
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-)
-
-from .const import DOMAIN
-from .coordinator import BirdBuddyDataUpdateCoordinator
-
-
-def _find_coordinator_by_feeder(
-    hass: HomeAssistant,
-    feeder_id: str,
-) -> BirdBuddyDataUpdateCoordinator:
-    """Find the first matching coordinator containing this `feeder_id`."""
-    coordinators: list[BirdBuddyDataUpdateCoordinator] = list(
-        hass.data[DOMAIN].values()
-    )
-    return next((c for c in coordinators if feeder_id in c.feeders), None)
-
-
-def _feeder_id_for_device(
-    hass: HomeAssistant,
-    device_id: str,
-) -> str:
-    """Return the Bird Buddy Feeder ID for this `device_id`."""
-    dev_reg = dr.async_get(hass)
-    if not (device_entry := dev_reg.async_get(device_id)):
-        raise ValueError(f"Device ID {device_id} not found")
-    return next((id for (d, id) in device_entry.identifiers if d == DOMAIN))
-
-
-def _find_coordinator_by_device(
-    hass: HomeAssistant,
-    device_id: str,
-) -> BirdBuddyDataUpdateCoordinator:
-    """Find the first coordinator for this `device_id`."""
-    dev_reg = dr.async_get(hass)
-    if not (device_entry := dev_reg.async_get(device_id)):
-        raise ValueError(f"Device ID {device_id} not found")
-
-    config_entry_ids = device_entry.config_entries
-    entry = next(
-        (
-            entry
-            for entry in hass.config_entries.async_entries(DOMAIN)
-            if entry.entry_id in config_entry_ids
-        )
-    )
-
-    if entry and entry.state != ConfigEntryState.LOADED:
-        raise ValueError(f"Device {device_id} config entry is not loaded")
-    if entry is None or entry.entry_id not in hass.data[DOMAIN]:
-        raise ValueError(
-            f"Device {device_id} is not from an existing birdbuddy config entry"
-        )
-    coordinator: BirdBuddyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    return coordinator
-
 
 def _find_media_with_species(feeder_id: str, items: list[FeedNode]) -> list[FeedNode]:
     return [

--- a/custom_components/birdbuddy/util.py
+++ b/custom_components/birdbuddy/util.py
@@ -1,5 +1,7 @@
 """Bird Buddy utilities"""
 
+from birdbuddy.feed import FeedNode
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
@@ -58,3 +60,20 @@ def _find_coordinator_by_device(
         )
     coordinator: BirdBuddyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     return coordinator
+
+
+def _find_media_with_species(feeder_id: str, items: list[FeedNode]) -> list[FeedNode]:
+    return [
+        item | {"media": next(iter(medias), None)}
+        for item in items
+        if item
+        and (
+            medias := [
+                m
+                for m in item.get("medias", [])
+                if m.get("__typename") == "MediaImage"
+                and feeder_id in m.get("thumbnailUrl", "")
+            ]
+        )
+        and item.get("species", None)
+    ]

--- a/custom_components/birdbuddy/visitors.py
+++ b/custom_components/birdbuddy/visitors.py
@@ -110,7 +110,7 @@ class RecentVisitors:
             LOGGER.debug(
                 "Setting recent visitor on %s from feed: %s, %s: %s",
                 self.feeder.name,
-                self._latest_species.name,
+                self._latest_species.name if self._latest_species else "Unknown species",
                 self._latest_media.created_at,
                 self._latest_media.content_url,
             )

--- a/custom_components/birdbuddy/visitors.py
+++ b/custom_components/birdbuddy/visitors.py
@@ -7,7 +7,6 @@ from birdbuddy.birds import Species
 from birdbuddy.client import BirdBuddy
 from birdbuddy.feed import FeedNodeType
 from birdbuddy.feeder import Feeder
-from birdbuddy.media import Media
 from birdbuddy.media import Media, is_media_expired
 from birdbuddy.sightings import PostcardSighting
 

--- a/custom_components/birdbuddy/visitors.py
+++ b/custom_components/birdbuddy/visitors.py
@@ -55,7 +55,7 @@ class RecentVisitors:
         if self._latest_media and not is_media_expired(
             self._latest_media.content_url or self._latest_media.thumbnail_url
         ):
-            listener(self._latest_media)
+            listener(self)
         self._listeners.add(listener)
         return lambda: self.unregister_callback(listener)
 

--- a/custom_components/birdbuddy/visitors.py
+++ b/custom_components/birdbuddy/visitors.py
@@ -1,0 +1,200 @@
+"""Helpers for managing recent visitors."""
+
+from typing import TypeVar
+from collections.abc import Callable
+
+from birdbuddy.birds import Species
+from birdbuddy.client import BirdBuddy
+from birdbuddy.feed import FeedNodeType
+from birdbuddy.feeder import Feeder
+from birdbuddy.media import Media
+from birdbuddy.media import Media, is_media_expired
+from birdbuddy.sightings import PostcardSighting
+
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import CALLBACK_TYPE
+
+from .const import EVENT_NEW_POSTCARD_SIGHTING, LOGGER
+from .util import _find_media_with_species
+
+_RecentVisitors = TypeVar("_RecentVisitors", bound="RecentVisitors")
+type VisitorCallback = Callable[[_RecentVisitors], None]
+
+
+class RecentVisitors:
+    """Class to manage recent visitors to this Feeder."""
+
+    def __init__(
+        self,
+        feeder: Feeder,
+        client: BirdBuddy,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the recent visitors manager."""
+        self.hass = hass
+        self.client = client
+        self.feeder = feeder
+        self._listeners: set[VisitorCallback] = set()
+        self._disposable: Callable[[], None] | None = None
+        self._latest_media: Media | None = None
+        self._latest_species: Species | None = None
+
+    @property
+    def latest_media(self) -> Media | None:
+        """Return the latest media."""
+        return self._latest_media
+
+    @property
+    def latest_species(self) -> Species | None:
+        """Return the latest species."""
+        return self._latest_species
+
+    def register_callback(self, listener: VisitorCallback) -> CALLBACK_TYPE:
+        """Register a callback to be called when a new visitor is detected."""
+        if not self._listeners:
+            self._disposable = self._start()
+        if self._latest_media and not is_media_expired(
+            self._latest_media.content_url or self._latest_media.thumbnail_url
+        ):
+            listener(self._latest_media)
+        self._listeners.add(listener)
+        return lambda: self.unregister_callback(listener)
+
+    def unregister_callback(self, listener: VisitorCallback) -> None:
+        """Unregister a callback."""
+        self._listeners.remove(listener)
+        if not self._listeners:
+            self._stop()
+
+    def _stop(self) -> None:
+        """Stop listening for new postcards."""
+        if self._disposable:
+            self._disposable()
+            self._disposable = None
+        LOGGER.info("Stopped listening for new visitors to feeder %s", self.feeder.name)
+
+    def _start(self) -> Callable[[], None]:
+        """Start listening for new postcards."""
+
+        @callback
+        def filter_my_postcards(event: Event) -> bool:
+            data = event if callable(getattr(event, "get", None)) else event.data
+            return self.feeder.id == (
+                data.get("sighting", {}).get("feeder", {}).get("id")
+            )
+
+        LOGGER.info("Listening for new visitors to feeder %s", self.feeder.name)
+        self.hass.add_job(self._update_latest_visitor)
+        return self.hass.bus.async_listen(
+            EVENT_NEW_POSTCARD_SIGHTING,
+            self._on_new_postcard,
+            event_filter=filter_my_postcards,
+        )
+
+    async def _update_latest_visitor(self) -> None:
+        feed = await self.client.feed()
+
+        items = feed.filter(
+            of_type=[
+                FeedNodeType.SpeciesSighting,
+                FeedNodeType.SpeciesUnlocked,
+                FeedNodeType.CollectedPostcard,
+            ],
+        )
+
+        my_items = _find_media_with_species(self.feeder.id, items)
+
+        if latest := max(my_items, default=None, key=lambda x: x.created_at):
+            self._latest_media = Media(latest["media"])
+            species = [Species(s) for s in latest.get("species", [])]
+            self._latest_species = next(iter(species), None)
+            LOGGER.debug(
+                "Setting recent visitor on %s from feed: %s, %s: %s",
+                self.feeder.name,
+                self._latest_species.name,
+                self._latest_media.created_at,
+                self._latest_media.content_url,
+            )
+
+        if not self._latest_species:
+            # Did not find media in the feed.
+            c = await self.client.refresh_collections()
+            c = [c for c in c.values() if c.feeder_name == self.feeder.name]
+            if c := max(c, default=None, key=(lambda x: x.last_visit)):
+                self._latest_species = c.species
+                # TODO: not easy to fetch latest media that matches a feeder
+                # c = await self.client.latest_collection_media(c.collection_id)
+                # m = max(c.values(), default=None, key=(lambda x: x.created_at))
+                # self._latest_media = m
+
+                LOGGER.debug(
+                    "Setting recent visitor on %s from collection: %s",
+                    self.feeder.name,
+                    self._latest_species.name,
+                )
+
+        # Notify listeners
+        self._notify_listeners()
+
+    def _notify_listeners(self) -> None:
+        """Notify listeners of the latest visitor."""
+        for listener in self._listeners:
+            listener(self)
+
+    async def _on_new_postcard(self, event: Event | None = None) -> None:
+        """Handle a new postcard sighting."""
+        postcard = PostcardSighting(event.data["sighting"])
+
+        assert postcard.report.sightings
+        assert postcard.medias
+
+        # media has created_at
+        # but sightings[] does not.
+        media = next(iter(postcard.medias), None)
+
+        if media:
+            self._latest_media = media
+
+        if unlocked := [
+            s for s in postcard.report.sightings if s.sighting_type.is_unlocked
+        ]:
+            # NOTE: this might not be correct - if one sighting has multiple recognized
+            # species, and one unlocked species, it's highly probably that the one unlocked
+            # species is a mis-identification!
+            # It's a little unusual for a single sighting to contain multiple bird species.
+            self._latest_species = unlocked[0].species
+            LOGGER.debug(
+                "Reporting recent visitor from unlocked: %s", self._latest_species.name
+            )
+        elif recognized := [
+            s for s in postcard.report.sightings if s.sighting_type.is_recognized
+        ]:
+            # Next best, select a recognized species
+            self._latest_species = recognized[0].species
+            LOGGER.debug(
+                "Reporting recent visitor from recognized: %s",
+                self._latest_species.name,
+            )
+        elif guessable := [s for s in postcard.report.sightings if s.suggestions]:
+            # Else, select one that has a list of suggestions
+            suggested = guessable[0].suggestions[0]
+            self._latest_species = suggested.species
+            LOGGER.info(
+                "Reporting recent visitor from unrecognized suggestion: %s",
+                suggested.species.name,
+            )
+        else:
+            # We don't know what it was. Instead of reporting a bogus "cannot decide"
+            # type, just clear the value.
+            self._latest_species = None
+            LOGGER.info("Cannot decide species: %s", postcard.report.sightings[0])
+
+        LOGGER.debug(
+            "Setting recent visitor on %s from postcard: %s, %s: %s",
+            self.feeder.name,
+            self._latest_species.name,
+            self._latest_media.created_at,
+            self._latest_media.content_url,
+        )
+
+        self._notify_listeners()


### PR DESCRIPTION
Adds the recent visitor image entity, removing the need for workarounds like adding a generic camera with a template URL.

To test this PR pre-release version, go to Developer tools > Actions, and run:
```
action: update.install
data:
  version: pr/image-entity
target:
  entity_id: update.bird_buddy_update
```