### PR TITLE
Bypass HA's content-type enforcement

### DIFF
--- a/custom_components/birdbuddy/image.py
+++ b/custom_components/birdbuddy/image.py
@@ -1,7 +1,11 @@
 """The Bird Buddy image entity."""
 
 from birdbuddy.media import Media, is_media_expired
-from homeassistant.components.image import UNDEFINED, ImageEntity
+from homeassistant.components.image import (
+    UNDEFINED,
+    ImageEntity,
+    Image,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -49,6 +53,18 @@ class BirdBuddyRecentVisitorImageEntity(BirdBuddyMixin, ImageEntity):
     def image(self) -> bytes | None:
         """Return the image bytes."""
         # See async_image()
+        return None
+
+    async def _async_load_image_from_url(self, url: str) -> Image | None:
+        """Load an image by url."""
+        # Override the parent because cloudfront is returning text/plain
+        # and HA requires image/*
+        # If there's an HTTP error, fetch_url will still raise that.
+        if response := await self._fetch_url(url):
+            return Image(
+                content=response.content,
+                content_type="image/jpeg",
+            )
         return None
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/birdbuddy/image.py
+++ b/custom_components/birdbuddy/image.py
@@ -56,10 +56,17 @@ class BirdBuddyRecentVisitorImageEntity(BirdBuddyMixin, ImageEntity):
         return None
 
     async def _async_load_image_from_url(self, url: str) -> Image | None:
-        """Load an image by url."""
-        # Override the parent because cloudfront is returning text/plain
-        # and HA requires image/*
-        # If there's an HTTP error, fetch_url will still raise that.
+        """
+        Load an image by URL, ensuring compatibility with Home Assistant.
+
+        This method overrides the parent implementation because cloudfront
+        sometimes returns a `text/plain` content type for image data, which
+        is incompatible with Home Assistant's requirement for `image/*`.
+        To address this, the content type is explicitly set to `image/jpeg`.
+
+        If there's an HTTP error, `fetch_url` will still raise the appropriate
+        exception.
+        """
         if response := await self._fetch_url(url):
             return Image(
                 content=response.content,


### PR DESCRIPTION
Home Assistant's ImageEntity enforces that the fetched image have an HTTP Content Type beginning with `image/*` and raises an error if it's not.

Bird Buddy's cloud provider (cloudfront) is returning content-type `text/plain` despite the response actually containing JPEG image bytes.

This bypasses the HA image loading in order to override the content-type to image/jpeg.