### PR TITLE
Clean up src/pybirdbuddy before dependency installation

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          rm -rf src/pybirdbuddy
           pip install -r requirements.test.txt
 
       - name: Run pytest


### PR DESCRIPTION
Remove the src/pybirdbuddy directory before installing dependencies.