### PR TITLE
Take the recent visitor image from the postcard, not from a mutation

### DIFF
--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from birdbuddy.client import BirdBuddy
+from birdbuddy.exceptions import CompositeException, GraphqlError
 from birdbuddy.feed import FeedNode, FeedNodeType
 from birdbuddy.feeder import Feeder
 from birdbuddy.media import Collection
@@ -54,6 +55,11 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             self.visitors[feeder.id] = RecentVisitors(feeder, self.client, self.hass)
         return self.visitors[feeder.id].register_callback(listener)
 
+    def _update_visitors_from_postcard(self, postcard: FeedNode) -> None:
+        """Offer a postcard's own media to the feeder it belongs to."""
+        for visitors in self.visitors.values():
+            visitors.update_from_postcard(postcard)
+
     async def _process_feed(self, feed: list[FeedNode]) -> bool:
         """Attempt to process new feed items.
 
@@ -78,6 +84,12 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
         LOGGER.debug("Found postcards %s", postcards)
         for postcard in postcards:
             LOGGER.debug("A new postcard is ready to process: %s", postcard)
+
+            # Publish the postcard's own image first, independently of
+            # everything below. The recent visitor image is a read; it should
+            # not depend on a mutation that collects a sighting.
+            self._update_visitors_from_postcard(postcard)
+
             if not self.hass.bus.async_listeners().get(EVENT_NEW_POSTCARD_SIGHTING):
                 # if no one is listening, no sense in getting sighting data
                 LOGGER.debug("No event listeners: skipping postcard conversion")
@@ -95,7 +107,22 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             # If this is a viable option, we can supply a Recipe in docs to show how this could
             # be done. Similarly, we can supply some default blueprints to handle this with
             # user input.
-            sighting = await self.client.sighting_from_postcard(postcard=postcard)
+            try:
+                sighting = await self.client.sighting_from_postcard(postcard=postcard)
+            except (GraphqlError, CompositeException) as exc:
+                # The API has been returning INTERNAL_SERVER_ERROR here since
+                # around April 2026 (#98). Letting it propagate turned one
+                # failed postcard into UpdateFailed for the whole coordinator,
+                # so every entity - battery, feeder state, the switches - went
+                # unavailable over a call none of them use. Skip the postcard
+                # and keep the update successful.
+                LOGGER.warning(
+                    "Could not convert postcard %s to a sighting; skipping it. "
+                    "The recent visitor image is unaffected. %s",
+                    postcard.node_id,
+                    exc,
+                )
+                continue
             data = {
                 "postcard": postcard.data,
                 "sighting": sighting.data,

--- a/custom_components/birdbuddy/manifest.json
+++ b/custom_components/birdbuddy/manifest.json
@@ -16,7 +16,7 @@
   ],
   "requirements": [
     "python-graphql-client==0.4.3",
-    "pybirdbuddy==0.0.20"
+    "pybirdbuddy==0.0.22"
   ],
   "ssdp": [],
   "version": "0.0.25",

--- a/custom_components/birdbuddy/visitors.py
+++ b/custom_components/birdbuddy/visitors.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 from birdbuddy.birds import Species
 from birdbuddy.client import BirdBuddy
-from birdbuddy.feed import FeedNodeType
+from birdbuddy.feed import FeedNode, FeedNodeType
 from birdbuddy.feeder import Feeder
 from birdbuddy.media import Media, is_media_expired
 from birdbuddy.sightings import PostcardSighting
@@ -90,6 +90,55 @@ class RecentVisitors:
             event_filter=filter_my_postcards,
         )
 
+    def media_from_postcard(self, postcard: FeedNode) -> Media | None:
+        """Return this feeder's newest usable image from a NewPostcard.
+
+        A postcard carries its own media, so this needs no
+        `sightingCreateFromPostcard` call. That matters because the mutation
+        currently returns INTERNAL_SERVER_ERROR from the Bird Buddy API, and
+        it is the only reason the image entity ever depended on a mutation.
+        """
+        if (feeder_id := postcard.feeder_id) and feeder_id != self.feeder.id:
+            return None
+
+        images = postcard.images
+        if not feeder_id:
+            # No feeder on the item: match on the signed media URL instead, the
+            # same way `_find_media_with_species` does.
+            images = [m for m in images if self.feeder.id in (m.thumbnail_url or "")]
+
+        if not (media := next(iter(images), None)):
+            return None
+        url = media.content_url or media.thumbnail_url
+        if not url or is_media_expired(url):
+            return None
+        return media
+
+    def update_from_postcard(self, postcard: FeedNode, notify: bool = True) -> bool:
+        """Adopt a postcard's media as the latest, if it is newer than ours."""
+        if not (media := self.media_from_postcard(postcard)):
+            return False
+
+        current = self._latest_media
+        if (
+            current
+            and (current_at := current.created_at)
+            and (new_at := media.created_at)
+            and new_at <= current_at
+        ):
+            return False
+
+        LOGGER.debug(
+            "Setting recent visitor on %s from postcard media: %s: %s",
+            self.feeder.name,
+            media.created_at,
+            media.content_url,
+        )
+        self._latest_media = media
+        if notify:
+            self._notify_listeners()
+        return True
+
     async def _update_latest_visitor(self) -> None:
         feed = await self.client.feed()
 
@@ -118,6 +167,12 @@ class RecentVisitors:
                 self._latest_media.created_at,
                 self._latest_media.content_url,
             )
+
+        # Uncollected postcards are usually newer than anything above, and on a
+        # feeder whose postcards are never collected they are the only source of
+        # an image at all. Each only replaces the current media if it is newer.
+        for postcard in feed.filter(of_type=FeedNodeType.NewPostcard):
+            self.update_from_postcard(postcard, notify=False)
 
         if not self._latest_species:
             # Did not find media in the feed.

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,0 +1,144 @@
+"""Tests for driving the recent visitor from a postcard's own media.
+
+The point of these is that none of them touch `sightingCreateFromPostcard`.
+"""
+
+from unittest.mock import MagicMock
+
+from birdbuddy.feed import FeedNode
+
+from custom_components.birdbuddy.visitors import RecentVisitors
+
+FEEDER_ID = "feeder-1"
+OTHER_FEEDER_ID = "feeder-2"
+
+# Signed media URLs carry an Expires param. 4102444800 is 2100-01-01.
+LIVE = "https://media.example.test/media/feeder/{f}/media/{m}/CONTENT.jpg?Expires=4102444800"
+EXPIRED = "https://media.example.test/media/feeder/{f}/media/{m}/CONTENT.jpg?Expires=1000000000"
+
+
+def _image(media_id: str, created_at: str, feeder_id: str = FEEDER_ID, url: str = LIVE):
+    formatted = url.format(f=feeder_id, m=media_id)
+    return {
+        "id": media_id,
+        "createdAt": created_at,
+        "thumbnailUrl": formatted,
+        "contentUrl": formatted,
+        "__typename": "MediaImage",
+    }
+
+
+def _postcard(medias: list, feeder_id: str | None = FEEDER_ID) -> FeedNode:
+    node = {
+        "id": "postcard-1",
+        "__typename": "FeedItemNewPostcard",
+        "createdAt": "2026-08-11T13:19:52.956Z",
+        "medias": medias,
+    }
+    if feeder_id is not None:
+        node["feeder"] = {
+            "id": feeder_id,
+            "name": "Feeder",
+            "__typename": "FeederForOwner",
+        }
+    return FeedNode(node)
+
+
+def _visitors() -> RecentVisitors:
+    feeder = MagicMock()
+    feeder.id = FEEDER_ID
+    feeder.name = "Feeder"
+    return RecentVisitors(feeder, MagicMock(), MagicMock())
+
+
+def test_media_taken_from_postcard_without_any_mutation():
+    """The newest image on the postcard becomes the latest media."""
+    visitors = _visitors()
+    assert visitors.update_from_postcard(
+        _postcard(
+            [
+                _image("older", "2026-08-11T12:24:19.693Z"),
+                _image("newer", "2026-08-11T13:19:49.779Z"),
+            ]
+        )
+    )
+    assert visitors.latest_media is not None
+    assert visitors.latest_media.id == "newer"
+
+
+def test_older_postcard_does_not_replace_newer_media():
+    """A postcard older than what we hold is ignored."""
+    visitors = _visitors()
+    visitors.update_from_postcard(_postcard([_image("newer", "2026-08-11T13:19:49.779Z")]))
+    assert not visitors.update_from_postcard(
+        _postcard([_image("older", "2026-08-11T12:24:19.693Z")])
+    )
+    assert visitors.latest_media.id == "newer"
+
+
+def test_postcard_for_another_feeder_is_ignored():
+    """Media belonging to a different feeder is never adopted."""
+    visitors = _visitors()
+    assert not visitors.update_from_postcard(
+        _postcard(
+            [_image("other", "2026-08-11T13:19:49.779Z", feeder_id=OTHER_FEEDER_ID)],
+            feeder_id=OTHER_FEEDER_ID,
+        )
+    )
+    assert visitors.latest_media is None
+
+
+def test_feeder_matched_by_media_url_when_item_has_no_feeder():
+    """With no feeder on the item, the signed media URL decides ownership."""
+    visitors = _visitors()
+    assert visitors.update_from_postcard(
+        _postcard([_image("mine", "2026-08-11T13:19:49.779Z")], feeder_id=None)
+    )
+    assert visitors.latest_media.id == "mine"
+
+    other = _visitors()
+    assert not other.update_from_postcard(
+        _postcard(
+            [_image("theirs", "2026-08-11T13:19:49.779Z", feeder_id=OTHER_FEEDER_ID)],
+            feeder_id=None,
+        )
+    )
+
+
+def test_expired_media_is_not_adopted():
+    """An already-expired signed URL is no use to the image entity."""
+    visitors = _visitors()
+    assert not visitors.update_from_postcard(
+        _postcard([_image("stale", "2026-08-11T13:19:49.779Z", url=EXPIRED)])
+    )
+    assert visitors.latest_media is None
+
+
+def test_postcard_without_images_is_ignored():
+    """No media, or video only, means nothing to show."""
+    visitors = _visitors()
+    assert not visitors.update_from_postcard(_postcard([]))
+    video = {
+        "id": "vid",
+        "createdAt": "2026-08-11T13:19:49.779Z",
+        "thumbnailUrl": LIVE.format(f=FEEDER_ID, m="vid"),
+        "__typename": "MediaVideo",
+    }
+    assert not visitors.update_from_postcard(_postcard([video]))
+    assert visitors.latest_media is None
+
+
+def test_listeners_notified_only_when_asked():
+    """notify=False lets a bulk feed scan defer to a single notification."""
+    visitors = _visitors()
+    seen = []
+    visitors.register_callback(seen.append)
+    seen.clear()
+
+    visitors.update_from_postcard(
+        _postcard([_image("quiet", "2026-08-11T12:24:19.693Z")]), notify=False
+    )
+    assert seen == []
+
+    visitors.update_from_postcard(_postcard([_image("loud", "2026-08-11T13:19:49.779Z")]))
+    assert seen == [visitors]


### PR DESCRIPTION
Fixes #98. Companion to jhansche/pybirdbuddy#50 — **needs a pybirdbuddy release
containing that PR**; the manifest pin here is a placeholder (`0.0.22`), happy
to change it to whatever you actually release.

## Why

`image.*_recent_visitor_image` is a read, but the only thing that ever fed it
was `sightingCreateFromPostcard`. That mutation has been returning
`INTERNAL_SERVER_ERROR` from the API since around April, so the entity has sat
at `unknown` ever since, and no client-side change to how we *call* it can fix
that.

It does not need the mutation. A postcard carries its own `medias`; with
pybirdbuddy#50 selecting them, the image comes straight off the feed. Showing a
picture no longer depends on a call whose job is collecting a sighting.

## What

**Image from the postcard.** `RecentVisitors.media_from_postcard()` /
`update_from_postcard()` take the newest non-video media off a `NewPostcard`,
check it belongs to this feeder and has not expired, and adopt it only if it is
newer than the current media. `_update_latest_visitor()` also scans
`NewPostcard` items now, so the entity populates at startup instead of waiting
for the next postcard — which matters on a fresh install, where the feed may
hold postcards but nothing collected.

Feeder ownership prefers the item's `feeder.id` and falls back to matching the
signed media URL, the same way `_find_media_with_species` already does.

**One 500 no longer takes out every entity.** `sighting_from_postcard` was
called inside `_async_update_data`'s try block, so a `GraphqlError` became
`UpdateFailed` for the whole coordinator — battery, feeder state and the
switches all went unavailable over a call none of them use. Now caught per
postcard, logged, and the update still succeeds.

## Deliberately not in scope

**Collection is still broken.** `finish_postcard`, the `collect_postcard`
service and the blueprint are untouched, because collecting genuinely does need
the failing mutation. The blueprint still will not fire, since the event it
listens for is only emitted after that call succeeds. This PR makes the image
work; it does not restore collection.

There may be a route to fixing that too — `postcardCollect` needs no
`reportToken` and did not fail where `sightingCreateFromPostcard` does. I have
written up what I could and could not verify in #98 rather than guessing at it
here.

## Checks

- 7 new tests: newest-media selection, older-postcard rejection, wrong-feeder
  rejection, URL-based feeder matching, expired media, video-only/empty
  postcards, and the notify flag.
- Full suite passes (20 tests).
- Running on a live feeder: HA's image proxy serves the postcard JPEG, the
  entity updates on the poll when a new postcard arrives, and the coordinator
  reports `success: True` while `sightingCreateFromPostcard` continues to 500.

## Disclosure

Produced by an AI coding agent (Claude Code), driven and reviewed by me. The
live verification is real but it is one feeder, one account. Please review it
as such — and I am happy to reshape or drop any of it.
