### PR TITLE
Don't fail the whole coordinator update on a single postcard-conversion error

### DIFF
--- a/custom_components/birdbuddy/coordinator.py
+++ b/custom_components/birdbuddy/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from birdbuddy.client import BirdBuddy
+from birdbuddy.exceptions import GraphqlError
 from birdbuddy.feed import FeedNode, FeedNodeType
 from birdbuddy.feeder import Feeder
 from birdbuddy.media import Collection
@@ -110,7 +111,21 @@ class BirdBuddyDataUpdateCoordinator(DataUpdateCoordinator[BirdBuddy]):
             # processing (e.g. Merlin or other classifiers), then do #2 with
             # the results. If viable, we can supply a Recipe in docs showing
             # how, plus default blueprints to handle it with user input.
-            sighting = await self.client.sighting_from_postcard(postcard=postcard)
+            try:
+                sighting = await self.client.sighting_from_postcard(postcard=postcard)
+            except GraphqlError as exc:
+                # The Bird Buddy cloud API occasionally returns a server error
+                # (e.g. INTERNAL_SERVER_ERROR) for this specific mutation.
+                # Don't let one bad postcard fail the entire coordinator
+                # update -- that would also mark unrelated data (e.g. feeder
+                # battery/food level) stale for this cycle. Log and move on
+                # to the next postcard instead; it'll be retried on the next
+                # update if it's still present in the feed.
+                LOGGER.error(
+                    "Failed to convert postcard to sighting; skipping this postcard: %s",
+                    exc,
+                )
+                continue
             data = {
                 "postcard": postcard.data,
                 "sighting": sighting.data,


### PR DESCRIPTION
## Problem

`sighting_from_postcard()` (called from `_process_feed()`) hits the `sightingCreateFromPostcard` GraphQL mutation. The Bird Buddy cloud API occasionally answers this specific mutation with a `GraphqlError` — observed in the wild as `INTERNAL_SERVER_ERROR`:

```
Error fetching birdbuddy data: INTERNAL_SERVER_ERROR: {'message': 'Internal server error.', 'locations': [...], 'path': ['sightingCreateFromPostcard'], 'extensions': {'code': 'INTERNAL_SERVER_ERROR', 'errorId': '...'}}
```

Because `_process_feed()` is called from inside `_async_update_data()`'s single `try/except Exception: raise UpdateFailed(...)`, one bad postcard is enough to fail the *entire* coordinator update for that cycle — so feeder battery, food level, and all other coordinator-backed data go stale too, not just the postcard/sighting event. Seen 3 times over ~1 hour on my instance, each with a distinct `errorId`, so it isn't a one-off.

## Fix

Catch `GraphqlError` around just the `sighting_from_postcard()` call inside the postcard loop, log it, and `continue` to the next postcard. Other postcards in the same feed batch, and all other coordinator data, are unaffected. If the postcard is still present in the feed on the next update, it's retried then — same as before, just scoped to that one item instead of the whole update.

Kept the fix narrowly scoped to error isolation. I noticed `sighting_from_postcard`/`finish_postcard` are marked deprecated upstream in pybirdbuddy (in favor of `identify_postcard`/`collect_postcard`) — happy to follow up with that migration separately if useful, but didn't want to bundle an API migration into a bug fix.

Verified: patched, restarted, and ran clean (no import/setup errors) against a live instance with pybirdbuddy 0.0.19.